### PR TITLE
add system-deps and mark ddcutil system lib dep

### DIFF
--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -17,3 +17,9 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 libc = "^0.2.36"
+
+[build-dependencies]
+system-deps = "2.0"
+
+[package.metadata.system-deps]
+ddcutil = "2.*"


### PR DESCRIPTION
This gets cargo to discover libddcutil, fixing
`ld: cannot find -lddcutil: No such file or directory` errors during linking in case the library is not in /usr/lib (like on NixOS).